### PR TITLE
Support queryables, keyword search and paging. Add associations and thumbnail to record properties.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,43 @@
+# =================================================================
+#
+# Authors: GeoCat BV <info@geocat.net>
+#
+# Copyright (c) 2021 Plateforme Géospatiale Canadienne (PGC) /
+#                    Canadian Geospatial Platform (CGP)
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+version: "3"
+
+services:
+
+  pygeoapi:
+    image: geopython/pygeoapi:latest
+
+    ports:
+      - "127.0.0.1:5000:80"
+
+    volumes:
+      - ../pygeoapi-config.yml:/pygeoapi/local.config.yml
+      - ../geocore_pygeoapi/provider/cgp.py:/pygeoapi/geocore_pygeoapi/provider/cgp.py

--- a/geocore_pygeoapi/provider/cgp.py
+++ b/geocore_pygeoapi/provider/cgp.py
@@ -109,15 +109,6 @@ class GeoCoreProvider(BaseProvider):
         return result
 
     @staticmethod
-    def _valid_id(identifier):
-        """ Returns True if the given identifier is a valid UUID. """
-        try:
-            str(UUID(identifier))
-        except (TypeError, ValueError, AttributeError):
-            return False
-        return True
-
-    @staticmethod
     def _asisodate(value):
         """ Returns an ISO formatted timestamp (with Z suffix) from a string.
         If the given value can't be turned into a date, `None` will be returned.
@@ -244,8 +235,8 @@ class GeoCoreProvider(BaseProvider):
 
             # Get ID and validate it
             id_ = item.pop('id', None)
-            if not self._valid_id(id_):
-                LOGGER.warning(f'skipped record with ID {id_}: not a UUID')
+            if id_ is None:
+                LOGGER.warning(f'skipped record without ID')
                 continue
             feature['id'] = id_
             item['externalId'] = id_
@@ -318,9 +309,7 @@ class GeoCoreProvider(BaseProvider):
             feature['properties'] = item
             features.append(feature)
 
-        if not features:
-            raise ProviderNoDataError('query returned nothing')
-        elif limit == 1:
+        if features and limit == 1:
             LOGGER.debug('returning single feature')
             return features[0]
 

--- a/geocore_pygeoapi/provider/cgp.py
+++ b/geocore_pygeoapi/provider/cgp.py
@@ -294,9 +294,11 @@ class GeoCoreProvider(BaseProvider):
                 item.setdefault('associations', []).append(lnk)
 
             # Remove graphicOverview and promote/set first thumbnailUrl
-            url = item.pop('graphicOverview', [{}])[0].get('overviewfilename')
-            if url:
+            try:
+                url = item.pop('graphicOverview')[0].get('overviewfilename')
                 item['thumbnailUrl'] = url
+            except (KeyError, IndexError, AttributeError):
+                LOGGER.warning('could not find overview thumbnail')
 
             # Set properties and add to feature list
             feature['properties'] = item

--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -39,19 +39,19 @@ server:
     pretty_print: true
     limit: 10
     # templates:
-      # path: /path/to/Jinja2/templates
-      # static: /path/to/static/folder # css/js/img
+    # path: /path/to/Jinja2/templates
+    # static: /path/to/static/folder # css/js/img
     map:
         url: https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
         attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia maps</a> | Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
-#    manager:
-#        name: TinyDB
-#        connection: /tmp/pygeoapi-process-manager.db
-#        output_dir: /tmp/
+    #    manager:
+    #        name: TinyDB
+    #        connection: /tmp/pygeoapi-process-manager.db
+    #        output_dir: /tmp/
     # ogc_schemas_location: /opt/schemas.opengis.net
 
 logging:
-    level: DEBUG
+    level: ERROR
     #logfile: /tmp/pygeoapi.log
 
 metadata:
@@ -96,36 +96,36 @@ resources:
             - observations
             - monitoring
         context:
-            - datetime: https://schema.org/DateTime
-            - vocab: https://example.com/vocab#
-              stn_id: "vocab:stn_id"
-              value: "vocab:value"
+            -   datetime: https://schema.org/DateTime
+            -   vocab: https://example.com/vocab#
+                stn_id: "vocab:stn_id"
+                value: "vocab:value"
         links:
-            - type: text/csv
-              rel: canonical
-              title: data
-              href: https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv
-              hreflang: en-US
-            - type: text/csv
-              rel: alternate
-              title: data
-              href: https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv
-              hreflang: en-US
+            -   type: text/csv
+                rel: canonical
+                title: data
+                href: https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv
+                hreflang: en-US
+            -   type: text/csv
+                rel: alternate
+                title: data
+                href: https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv
+                hreflang: en-US
         extents:
             spatial:
-                bbox: [-180,-90,180,90]
+                bbox: [ -180,-90,180,90 ]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
             temporal:
                 begin: 2000-10-30T18:24:39Z
                 end: 2007-10-30T08:57:29Z
         providers:
-            - type: feature
-              name: CSV
-              data: tests/data/obs.csv
-              id_field: id
-              geometry:
-                  x_field: long
-                  y_field: lat
+            -   type: feature
+                name: CSV
+                data: tests/data/obs.csv
+                id_field: id
+                geometry:
+                    x_field: long
+                    y_field: lat
 
     lakes:
         type: collection
@@ -134,24 +134,24 @@ resources:
         keywords:
             - lakes
         links:
-            - type: text/html
-              rel: canonical
-              title: information
-              href: http://www.naturalearthdata.com/
-              hreflang: en-US
+            -   type: text/html
+                rel: canonical
+                title: information
+                href: http://www.naturalearthdata.com/
+                hreflang: en-US
         extents:
             spatial:
-                bbox: [-180,-90,180,90]
+                bbox: [ -180,-90,180,90 ]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
             temporal:
                 begin: 2011-11-11
                 end: null  # or empty (either means open ended)
         providers:
-            - type: feature
-              name: GeoJSON
-              data: tests/data/ne_110m_lakes.geojson
-              id_field: id
-              title_field: name
+            -   type: feature
+                name: GeoJSON
+                data: tests/data/ne_110m_lakes.geojson
+                id_field: id
+                title_field: name
 
     gdps-temperature:
         type: collection
@@ -162,23 +162,23 @@ resources:
             - global
         extents:
             spatial:
-                bbox: [-180,-90,180,90]
+                bbox: [ -180,-90,180,90 ]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
-            - type: text/html
-              rel: canonical
-              title: information
-              href: https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en
-              hreflang: en-CA
+            -   type: text/html
+                rel: canonical
+                title: information
+                href: https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en
+                hreflang: en-CA
         providers:
-            - type: coverage
-              name: rasterio
-              data: tests/data/CMC_glb_TMP_TGL_2_latlon.15x.15_2020081000_P000.grib2
-              options:
-                  DATA_ENCODING: COMPLEX_PACKING
-              format:
-                  name: GRIB2
-                  mimetype: application/x-grib2
+            -   type: coverage
+                name: rasterio
+                data: tests/data/CMC_glb_TMP_TGL_2_latlon.15x.15_2020081000_P000.grib2
+                options:
+                    DATA_ENCODING: COMPLEX_PACKING
+                format:
+                    name: GRIB2
+                    mimetype: application/x-grib2
 
     test-data:
         type: stac-collection
@@ -188,26 +188,26 @@ resources:
             - poi
             - portugal
         links:
-            - type: text/html
-              rel: canonical
-              title: information
-              href: https://github.com/geopython/pygeoapi/tree/master/tests/data
-              hreflang: en-US
+            -   type: text/html
+                rel: canonical
+                title: information
+                href: https://github.com/geopython/pygeoapi/tree/master/tests/data
+                hreflang: en-US
         extents:
             spatial:
-                bbox: [-180,-90,180,90]
+                bbox: [ -180,-90,180,90 ]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         providers:
-            - type: stac
-              name: FileSystem
-              data: tests/data
-              file_types:
-                  - .gpkg
-                  - .sqlite
-                  - .csv
-                  - .grib2
-                  - .tif
-                  - .shp
+            -   type: stac
+                name: FileSystem
+                data: tests/data
+                file_types:
+                    - .gpkg
+                    - .sqlite
+                    - .csv
+                    - .grib2
+                    - .tif
+                    - .shp
 
     canada-metadata:
         type: collection
@@ -217,29 +217,29 @@ resources:
             - canada
             - open data
         links:
-            - type: text/html
-              rel: canonical
-              title: information
-              href: https://open.canada.ca/en/open-data
-              hreflang: en-CA
+            -   type: text/html
+                rel: canonical
+                title: information
+                href: https://open.canada.ca/en/open-data
+                hreflang: en-CA
         extents:
             spatial:
-                bbox: [-180,-90,180,90]
+                bbox: [ -180,-90,180,90 ]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         providers:
-            - type: record
-              name: TinyDBCatalogue
-              data: tests/data/open.canada.ca/sample-records.db
-              id_field: externalId
-              time_field: record-created
-              title_field: title
+            -   type: record
+                name: TinyDBCatalogue
+                data: tests/data/open.canada.ca/sample-records.tinydb
+                id_field: externalId
+                time_field: record-created
+                title_field: title
 
     hello-world:
         type: process
         processor:
             name: HelloWorld
 
-    nrcan-geocore:
+    canadian-geospatial-platform:
         type: collection
         title: Canadian Geospatial Platform (CGP) records
         description: Canadian Geospatial Platform records (geoCore API)
@@ -250,24 +250,40 @@ resources:
             - fgp
             - cgp
         links:
-            - type: text/html
-              rel: canonical
-              title: information
-              href: https://www.nrcan.gc.ca/science-data/science-research/earth-sciences/geomatics/canadas-spatial-data-infrastruct/geospatial-communities-canada-ce/federal-geospatial-platform/11031
-              hreflang: en-CA
+            -   type: text/html
+                rel: canonical
+                title: information
+                href: https://www.nrcan.gc.ca/science-data/science-research/earth-sciences/geomatics/canadas-spatial-data-infrastruct/geospatial-communities-canada-ce/federal-geospatial-platform/11031
+                hreflang: en-CA
         extents:
             spatial:
-                bbox: [-180,-90,180,90]
+                bbox: [ -180,-90,180,90 ]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         providers:
-            - type: record
-              name: geocore_pygeoapi.provider.cgp.GeoCoreProvider
-              data:
-                  base_url: https://hqdatl0f6d.execute-api.ca-central-1.amazonaws.com/dev
-                  mapping:
-                      # Maps provider function calls to specific endpoints
-                      query: geo
-                      get: id
-              id_field: externalId
-              time_field: record-created
-              title_field: title
+            -   type: record
+                name: geocore_pygeoapi.provider.cgp.GeoCoreProvider
+                data:
+                    base_url: https://hqdatl0f6d.execute-api.ca-central-1.amazonaws.com/dev
+                    mapping:
+                        # Maps provider function calls to specific endpoints
+                        query: geo
+                        get: id
+                    queryables:
+                        # geoCore does not offer a way to retrieve the queryables: define them here
+                        theme:
+                            type: string
+                            values:
+                                - administration
+                                - economy
+                                - environment
+                                - imagery
+                                - infrastructure
+                                - science
+                                - society
+                                - legal
+                                - emergency
+                        org:
+                            type: string
+                id_field: externalId
+                time_field: record-created
+                title_field: title


### PR DESCRIPTION
- Adds support for the `org` and `theme` geoCore search parameters. 
- Fixes paging by setting the `numberMatched` property on the result object (fixes issue #3). 
- Added support for geoCore `keyword` search (`q` parameter).
- Added `associations` (from geoCore `options`) to record (issue #5).
- Added `thumbnailUrl` (from geoCore `graphicOverview`) to record (issue #4).

Also adds a minimal Docker compose setup for local testing.